### PR TITLE
Add Achievement Progress Tracking and Cards

### DIFF
--- a/halo-collectibles/src/common/AchievementCategory.jsx
+++ b/halo-collectibles/src/common/AchievementCategory.jsx
@@ -1,45 +1,25 @@
 import React from "react";
 import AlertMessage from "./AlertMessage";
-import { Table } from "reactstrap";
-import { MdCheckCircle } from "react-icons/md";
+import { Col, Row } from "reactstrap";
+import AchievementCard from "./achievements/AchievementCard";
 
 const AchievementCategory = ({ achievements }) => {
   if (achievements.length === 0) {
     return (
       <AlertMessage color="info" isVisible>
-        No Achievements to Display
+        No Achievements found!
       </AlertMessage>
     );
   }
 
   return (
-    <Table striped hover>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Gamerscore</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        {achievements.map((ach) => (
-          <tr key={ach.name}>
-            <td>
-              {ach?.isComplete && (
-                <MdCheckCircle
-                  className="mr-2"
-                  style={{ verticalAlign: "sub" }}
-                  size={17}
-                />
-              )}
-              {ach.name}
-            </td>
-            <td>{ach.score}</td>
-            <td>{ach.description}</td>
-          </tr>
-        ))}
-      </tbody>
-    </Table>
+    <Row noGutters>
+      {achievements.map((ach) => (
+        <Col lg={4} md={6} xs={12}>
+          <AchievementCard achievement={ach} key={ach.name} />
+        </Col>
+      ))}
+    </Row>
   );
 };
 

--- a/halo-collectibles/src/common/AchievementProgress.jsx
+++ b/halo-collectibles/src/common/AchievementProgress.jsx
@@ -14,17 +14,26 @@ export default ({ achievement }) => {
 
   const userAchievement = achievements.find((a) => a.name === achievement.name);
 
-  if (userAchievement === undefined) {
+  if (
+    userAchievement === undefined ||
+    userAchievement.target === undefined ||
+    userAchievement.target === 1
+  ) {
     return null;
   }
 
   const { progress, current, target } = userAchievement;
-  const id = achievement.name.replace(/ /g, "-").replace(/[?.,:!"']/g, "");
+  const id =
+    achievement.name.replace(/ /g, "-").replace(/[?.,:!"']/g, "") + "-tooltip";
 
   return (
     <div>
-      <Progress color="info" value={progress * 100} id={id} />
-      <Tooltip placement="left" isOpen={tooltip} target={id} toggle={toggle}>
+      <Progress
+        color={progress > 1 ? "success" : "info"}
+        value={progress * 100}
+        id={id}
+      />
+      <Tooltip placement="top" isOpen={tooltip} target={id} toggle={toggle}>
         {current} / {target}
       </Tooltip>
     </div>

--- a/halo-collectibles/src/common/AchievementProgress.jsx
+++ b/halo-collectibles/src/common/AchievementProgress.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import UserContext from "../UserContext";
+import { Progress, Tooltip } from "reactstrap";
+
+export default ({ achievement }) => {
+  const { achievements } = React.useContext(UserContext).user;
+  const [tooltip, openTooltip] = useState(false);
+
+  const toggle = () => openTooltip(!tooltip);
+
+  if (achievements === undefined || achievements.length === 0) {
+    return null;
+  }
+
+  const userAchievement = achievements.find((a) => a.name === achievement.name);
+
+  if (userAchievement === undefined) {
+    return null;
+  }
+
+  const { progress, current, target } = userAchievement;
+  const id = achievement.name.replace(/ /g, "-").replace(/[?.,:!"']/g, "");
+
+  return (
+    <div>
+      <Progress color="info" value={progress * 100} id={id} />
+      <Tooltip placement="left" isOpen={tooltip} target={id} toggle={toggle}>
+        {current} / {target}
+      </Tooltip>
+    </div>
+  );
+};

--- a/halo-collectibles/src/common/Achievements.jsx
+++ b/halo-collectibles/src/common/Achievements.jsx
@@ -44,7 +44,9 @@ const Achievements = ({ categories }) => {
 
   if (user.achievements.length > 0) {
     achievements = achievements.map((ach) => {
-      let userProgress = user.achievements.find((x) => x.name === ach.name);
+      let userProgress = user.achievements.find(
+        (x) => x.name.toLowerCase() === ach.name.toLowerCase()
+      );
 
       return userProgress ?? { ...ach, isComplete: false };
     });

--- a/halo-collectibles/src/common/UserLogin.jsx
+++ b/halo-collectibles/src/common/UserLogin.jsx
@@ -26,7 +26,7 @@ export default () => {
   const getProgress = (xuid) => {
     console.log(xuid);
     return fetch(
-      "https://halocollectiblesapi.azurewebsites.net/api/GetHal?xuid=" + xuid
+      "https://halocollectiblesapi.azurewebsites.net/api/GetHalo?xuid=" + xuid
     ).then((response) => {
       if (response.ok) {
         return response.json();

--- a/halo-collectibles/src/common/achievements/AchievementCard.jsx
+++ b/halo-collectibles/src/common/achievements/AchievementCard.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import AchievementProgress from "../AchievementProgress";
+import { MdCheckCircle } from "react-icons/md";
+import "./achievements.css";
+
+export default ({ achievement }) => {
+  return (
+    <div className="achievement-card">
+      <div className="achievement-card__title">{achievement.name}</div>
+      <span className="achievement-card__score">
+        {achievement.isComplete && <MdCheckCircle size={15} />}
+        {achievement.score}
+      </span>
+      <div className="achievement-card__description">
+        {achievement.description}
+      </div>
+      <div className="achievement-card__progress">
+        <AchievementProgress achievement={achievement} />
+      </div>
+    </div>
+  );
+};

--- a/halo-collectibles/src/common/achievements/achievements.css
+++ b/halo-collectibles/src/common/achievements/achievements.css
@@ -1,0 +1,35 @@
+.achievement-card {
+  margin: 0.5rem;
+  border: 1px solid #434343;
+  background-color: #242424;
+}
+
+.achievement-card__title {
+  font-weight: bold;
+  font-size: 105%;
+  padding: 0.25rem 0.5rem;
+  display: inline-block;
+}
+
+.achievement-card__score {
+  float: right;
+  margin: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.achievement-card__score svg {
+  margin-right: 3px;
+  color: #62c462;
+}
+
+.achievement-card__description {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.achievement-card__progress .progress {
+  border-radius: 0;
+  height: 0.5rem;
+}

--- a/halo-collectibles/src/features/halo2/achievements.json
+++ b/halo-collectibles/src/features/halo2/achievements.json
@@ -119,7 +119,7 @@
       "title": "Armory",
       "achievements": [
         {
-          "name": "Skulltaker Halo 2: That's Just...Wrong",
+          "name": "Skulltaker Halo 2: That's Just…Wrong",
           "score": 5,
           "description": "Find and claim the That's Just...Wrong Skull"
         }
@@ -384,7 +384,7 @@
           "description": "Beat the par score on Regret"
         },
         {
-          "name": "Enamored",
+          "name": "Enamoured",
           "score": 5,
           "description": "Activate Terminal 7 on Regret"
         },
@@ -504,7 +504,7 @@
           "description": "Beat the par score on Gravemind"
         },
         {
-          "name": "Knowledgable",
+          "name": "Knowledgeable",
           "score": 5,
           "description": "Activate Terminal 10 on Gravemind"
         },

--- a/halo-collectibles/src/features/halo3/achievements.json
+++ b/halo-collectibles/src/features/halo3/achievements.json
@@ -64,7 +64,7 @@
           "description": "Complete a Halo 3 playlist"
         },
         {
-          "name": "Afficiando",
+          "name": "Aficiando",
           "score": 20,
           "description": "Complete three Halo 3 playlists"
         },

--- a/halo-collectibles/src/features/haloce/achievements.json
+++ b/halo-collectibles/src/features/haloce/achievements.json
@@ -33,7 +33,7 @@
         "description": "Beat the par score on all Halo: CE levels"
       },
       {
-        "name": "Dear Diary",
+        "name": "Dear Diary...",
         "score": 20,
         "description": "Activate all Halo: CE Terminals",
         "link": "https://www.xboxachievements.com/game/halo-the-master-chief-collection/achievement/93716-Dear-Diary---.html"
@@ -107,7 +107,7 @@
     "title": "The Pillar of Autumn",
     "achievements": [
       {
-        "name": "The Pillar of Autumn",
+        "name": "Pillar of Autumn",
         "score": 10,
         "description": "Complete The Pillar of Autumn"
       },
@@ -235,7 +235,7 @@
         "link": "https://www.xboxachievements.com/game/halo-the-master-chief-collection/achievement/93981-Close-Quarters-Combat.html"
       },
       {
-        "name": "All According to Play...",
+        "name": "All According to Plan...",
         "score": 10,
         "description": "Kill the first group of enemies on The Truth and Reconciliation without being detected",
         "link": "https://www.xboxachievements.com/game/halo-the-master-chief-collection/achievement/93984-All-According-to-Plan---.html"
@@ -272,9 +272,9 @@
         "link": "http://www.youtube.com/watch?v=hf3W9NRtS7w"
       },
       {
-        "name": "Skulltaker Halo: CE: Bandanna Skull",
+        "name": "Skulltaker Halo: CE: Bandana Skull",
         "score": 5,
-        "description": "Find and claim the Bandanna skull in remastered mode on The Silent Cartographer",
+        "description": "Find and claim the Bandana skull in remastered mode on The Silent Cartographer",
         "link": "http://www.youtube.com/watch?v=oMlJA8_E1vk"
       },
       {
@@ -300,7 +300,7 @@
         "description": "Complete Assault on the Control Room"
       },
       {
-        "name": "Would It've Killed You to Take the Elevator",
+        "name": "Would It've Killed You to Take the Lift",
         "score": 10,
         "description": "Beat the par time on Assault on the Control Room"
       },

--- a/halo-collectibles/src/features/haloce/achievements.json
+++ b/halo-collectibles/src/features/haloce/achievements.json
@@ -386,7 +386,7 @@
         "description": "Complete The Library"
       },
       {
-        "name": "TLLDR",
+        "name": "TLDR",
         "score": 10,
         "description": "Beat the par time on The Library"
       },


### PR DESCRIPTION
In order to make the Achievement Progress tracking more palatable, I've updated the layout to be cards instead of a single table. While this will mean there are potentially less achievements on the screen at one time, I don't think that is necessarily a bad thing in this case, since it will prevent cognitive overload a bit.

Additionally, there are typo fixes and a `.toLowerCase()` call when matching achievement names.